### PR TITLE
Allow connection options

### DIFF
--- a/src/cooler/schemas/redis/connection_options.clj
+++ b/src/cooler/schemas/redis/connection_options.clj
@@ -22,17 +22,18 @@
    (s/optional-key :test-while-idle?)                s/Bool
    (s/optional-key :time-between-eviction-runs-ms)   s/Int})
 
-(s/defschema ^:private AuthHostPort
-  {:host s/Str
-   :port s/Int})
-
-(s/defschema ^:private AuthURI
-  {:uri s/Str})
-
 (s/defschema ^:private AuthOptions
   {(s/optional-key :password)   s/Str
    (s/optional-key :timeout-ms) s/Int
    (s/optional-key :db)         s/Int})
+
+(s/defschema ^:private AuthHostPort
+  (merge {:host s/Str
+          :port s/Int}
+         AuthOptions))
+
+(s/defschema ^:private AuthURI
+  (merge {:uri s/Str} AuthOptions))
 
 (s/defschema ^:private ConnectionSpec
   (s/conditional
@@ -51,4 +52,4 @@
           :else        PoolConfig)
    :spec (s/conditional
           #(= % {}) (s/eq {})
-          :else     (s/maybe (merge ConnectionSpec AuthOptions)))})
+          :else     (s/maybe ConnectionSpec))})


### PR DESCRIPTION
This fixes the immediate issue of `:timeout-ms` being unusable. However there's a whole lot of options in carmine that are just not being passed through properly because of these schemas: https://github.com/taoensso/carmine/blob/v3.3.2/src/taoensso/carmine/connections.clj#L273-L274 . If carmine doesn't provide a schema, it might be worthwhile to just not check since these are just pass-through.